### PR TITLE
Correct the name of the search page location.

### DIFF
--- a/exampleSite/content/docs/search-support.md
+++ b/exampleSite/content/docs/search-support.md
@@ -23,10 +23,7 @@ Follow the following steps for enabling search in your site.
 
 First of all, you'll need to create a search page.
 
-Create a markdown file under `/content/page/` directory with the filename `search`. If your site is multilingual, you can include language code in the filename. For example:
-
-- `/content/page/search.md`
-- `/content/page/search.en.md`
+Create a markdown file under `/content/search/` directory with the filename `_index.md`.
 
 Add the following options in the frontmatter:
 


### PR DESCRIPTION
content/page/search.md does not work since the search form's action url is "search/?q=xx" not the "page/search/?q=xx".

I also don't think we should change the search.html layout since page/ is a too general name for a section and can be used for other purpose.

I don't know how to change for multi language correspondingly though.