### PR TITLE
Fix display of article tags with slashes

### DIFF
--- a/layouts/partials/entry/taxonomy-list.html
+++ b/layouts/partials/entry/taxonomy-list.html
@@ -8,7 +8,7 @@
   <span class='screen-reader-text'>{{ ( ( i18n $tx 2 ) | default $txs ) }}: </span>
   {{- range $i, $term := ( index $.Params $txs ) -}}
     {{- if gt $i 0 }}, {{ end -}}
-    {{- with ( index $taxonomies ( $term | anchorize ) ) -}}
+    {{- with ( index $taxonomies ( $term | urlize ) ) -}}
     <a class='{{ $tx }}' href='{{ .Page.RelPermalink }}'>
       {{- .Page.Title -}}
     </a>


### PR DESCRIPTION
Tags with a slash, like "CI/CD", were not displaying with anchorize. 